### PR TITLE
Add support for Vec<T>

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,4 +27,6 @@ jobs:
 
       # Run cargo-release
       - name: Release the crate
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: nix develop --command cargo release "${{ github.event.inputs.releaseType }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,7 @@ version = "0.1.0"
 dependencies = [
  "ex_em_ell_derive",
  "insta",
+ "itertools",
  "thiserror",
  "xml-rs",
 ]

--- a/ex_em_ell/Cargo.toml
+++ b/ex_em_ell/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://github.com/amy-keibler/ex_em_ell"
 
 [dependencies]
 ex_em_ell_derive = { path = "../ex_em_ell_derive", version = "0.1.0", optional = true }
+itertools = "0.12.1"
 thiserror = "1.0.57"
 xml-rs = "0.8.19"
 

--- a/ex_em_ell/src/lib.rs
+++ b/ex_em_ell/src/lib.rs
@@ -10,9 +10,11 @@ use errors::{XmlReadError, XmlWriteError};
 use xml::{EmitterConfig, EventReader, EventWriter, ParserConfig};
 
 #[cfg(feature = "derive")]
-pub use ex_em_ell_derive::{FromXmlDocument, FromXmlElement, ToXmlDocument, ToXmlElement};
+pub use ex_em_ell_derive::{
+    FromXmlDocument, FromXmlElement, NamedXmlElement, ToXmlDocument, ToXmlElement,
+};
 
-pub use traits::{FromXmlDocument, FromXmlElement, ToXmlDocument, ToXmlElement};
+pub use traits::{FromXmlDocument, FromXmlElement, NamedXmlElement, ToXmlDocument, ToXmlElement};
 pub extern crate xml;
 
 pub fn to_string<T: ToXmlDocument>(value: &T) -> Result<String, XmlWriteError> {

--- a/ex_em_ell/src/xml_utils.rs
+++ b/ex_em_ell/src/xml_utils.rs
@@ -1,8 +1,12 @@
+use itertools::Itertools;
 use std::io::{Read, Write};
 
 use xml::{name::OwnedName, reader, writer, EventReader, EventWriter};
 
-use crate::errors::{XmlReadError, XmlWriteError};
+use crate::{
+    errors::{XmlReadError, XmlWriteError},
+    FromXmlElement,
+};
 
 /// Write a tag that is of the form `<tag>content</tag>`
 pub fn write_simple_tag<W: Write>(
@@ -40,6 +44,48 @@ pub fn read_simple_tag<R: Read>(
         .and_then(closing_tag_or_error(element))?;
 
     Ok(content)
+}
+
+pub fn read_list_tag<R: Read, T: FromXmlElement>(
+    event_reader: &mut EventReader<R>,
+    element_name: &OwnedName,
+    inner_element_tag: &str,
+) -> Result<Vec<T>, XmlReadError> {
+    let mut items = Vec::new();
+
+    let mut got_end_tag = false;
+    while !got_end_tag {
+        let next_element = event_reader
+            .next()
+            .map_err(to_xml_read_error(&element_name.local_name))?;
+        match next_element {
+            reader::XmlEvent::StartElement {
+                name,
+                attributes,
+                namespace,
+                ..
+            } if name.local_name == inner_element_tag => {
+                items.push(T::from_xml_element(
+                    event_reader,
+                    &name,
+                    &attributes,
+                    &namespace,
+                )?);
+            }
+            reader::XmlEvent::EndElement { name } if &name == element_name => {
+                got_end_tag = true;
+            }
+            unexpected => {
+                return Err(unexpected_element_with_known_values_error(
+                    element_name,
+                    vec![inner_element_tag.to_string()],
+                    unexpected,
+                ))
+            }
+        }
+    }
+
+    Ok(items)
 }
 
 pub fn inner_text_or_error(
@@ -85,6 +131,21 @@ pub fn unexpected_element_error(
 ) -> XmlReadError {
     XmlReadError::UnexpectedElementReadError {
         error: format!("Got unexpected element {:?}", unexpected),
+        element: element.to_string(),
+    }
+}
+
+pub fn unexpected_element_with_known_values_error(
+    element: impl ToString,
+    valid_elements: Vec<String>,
+    unexpected: xml::reader::XmlEvent,
+) -> XmlReadError {
+    XmlReadError::UnexpectedElementReadError {
+        error: format!(
+            "Got unexpected element {:?}, expected one of: {}",
+            unexpected,
+            valid_elements.iter().join(", ")
+        ),
         element: element.to_string(),
     }
 }

--- a/ex_em_ell/tests/data/lists/valid_empty.xml
+++ b/ex_em_ell/tests/data/lists/valid_empty.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<example>
+  <children />
+</example>

--- a/ex_em_ell/tests/data/lists/valid_example.xml
+++ b/ex_em_ell/tests/data/lists/valid_example.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<example>
+  <children>
+    <child>
+      <field>value</field>
+    </child>
+  </children>
+</example>

--- a/ex_em_ell/tests/data/lists/valid_multiple.xml
+++ b/ex_em_ell/tests/data/lists/valid_multiple.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<example>
+  <children>
+    <child>
+      <field>value</field>
+    </child>
+    <child>
+      <field>value</field>
+    </child>
+  </children>
+</example>

--- a/ex_em_ell/tests/lists.rs
+++ b/ex_em_ell/tests/lists.rs
@@ -1,0 +1,24 @@
+#[derive(Debug, PartialEq, ex_em_ell::FromXmlDocument, ex_em_ell::ToXmlDocument)]
+struct Example {
+    children: Vec<ExampleChild>,
+}
+
+#[derive(
+    Debug, PartialEq, ex_em_ell::FromXmlElement, ex_em_ell::ToXmlElement, ex_em_ell::NamedXmlElement,
+)]
+#[ex_em_ell(name = "child")]
+struct ExampleChild {
+    field: String,
+}
+
+#[test]
+fn test_example_xmls() {
+    insta::glob!("data/lists/valid_*.xml", |path| {
+        let file = std::fs::File::open(path).expect(&format!("Failed to read file: {path:?}"));
+        let example: Example = ex_em_ell::from_reader(&file)
+            .expect(&format!("Failed to parse the XML file: {path:?}"));
+
+        let round_trip = ex_em_ell::to_string_pretty(&example).expect("Failed to output XML");
+        insta::assert_snapshot!(round_trip);
+    });
+}

--- a/ex_em_ell/tests/snapshots/lists__example_xmls@valid_empty.xml.snap
+++ b/ex_em_ell/tests/snapshots/lists__example_xmls@valid_empty.xml.snap
@@ -1,0 +1,9 @@
+---
+source: ex_em_ell/tests/lists.rs
+expression: round_trip
+input_file: ex_em_ell/tests/data/lists/valid_empty.xml
+---
+<?xml version="1.0" encoding="utf-8"?>
+<example>
+  <children />
+</example>

--- a/ex_em_ell/tests/snapshots/lists__example_xmls@valid_example.xml.snap
+++ b/ex_em_ell/tests/snapshots/lists__example_xmls@valid_example.xml.snap
@@ -1,0 +1,13 @@
+---
+source: ex_em_ell/tests/lists.rs
+expression: round_trip
+input_file: ex_em_ell/tests/data/lists/valid_example.xml
+---
+<?xml version="1.0" encoding="utf-8"?>
+<example>
+  <children>
+    <child>
+      <field>value</field>
+    </child>
+  </children>
+</example>

--- a/ex_em_ell/tests/snapshots/lists__example_xmls@valid_multiple.xml.snap
+++ b/ex_em_ell/tests/snapshots/lists__example_xmls@valid_multiple.xml.snap
@@ -1,0 +1,16 @@
+---
+source: ex_em_ell/tests/lists.rs
+expression: round_trip
+input_file: ex_em_ell/tests/data/lists/valid_multiple.xml
+---
+<?xml version="1.0" encoding="utf-8"?>
+<example>
+  <children>
+    <child>
+      <field>value</field>
+    </child>
+    <child>
+      <field>value</field>
+    </child>
+  </children>
+</example>


### PR DESCRIPTION
- Add a NamedXmlElement trait that can be used to give the canonical representation of a type in a Vec
  - Fall back to the lower camel case of the type
- Add support for the publishing environment variable in the GitHub action